### PR TITLE
Update so each component uses it's own ContextMenu

### DIFF
--- a/src/components/MapList.hx
+++ b/src/components/MapList.hx
@@ -3,14 +3,18 @@ package components;
 import haxe.ui.events.MouseEvent;
 import haxe.ui.containers.TreeViewNode;
 import haxe.ui.containers.TreeView;
+import components.menus.ContextMenu;
 import components.menus.ContextMenuEntry;
 
 @:build(haxe.ui.macros.ComponentMacros.ComponentMacros.build('assets/main/maplist.xml'))
 class MapList extends TreeView {
+  public var contextMenu: ContextMenu;
   public var worldNode: TreeViewNode;
 
   public function new() {
     super();
+    contextMenu = new ContextMenu();
+    contextMenu.items = menu();
     worldNode = addNode({ text: 'World' });
     worldNode.expanded = true;
   }
@@ -46,8 +50,19 @@ class MapList extends TreeView {
     ];
   }
 
+  @:bind(this, MouseEvent.RIGHT_MOUSE_DOWN)
+  private function onContextMenu(e: MouseEvent) {
+    if (selectedNode != null) {
+      if (selectedNode.hitTest(e.screenX, e.screenY)) {
+        contextMenu.left = e.screenX;
+        contextMenu.top = e.screenY;
+        contextMenu.show();
+      }
+    }
+  }
+
   public function onNewMap(event: MouseEvent) {
-    selectedNode.addNode({text: 'New Map'});
+    selectedNode.addNode({ text: 'New Map' });
   }
 
   public function onDeleteMap(event: MouseEvent) {

--- a/src/components/MapList.hx
+++ b/src/components/MapList.hx
@@ -50,8 +50,22 @@ class MapList extends TreeView {
     ];
   }
 
+  private function forceSelectNode(x, y) {
+    // A hacky way to ensure the TreeViewNode is selected before right click
+    // actions
+    var nodesUnderPoint = findComponentsUnderPoint(x, y);
+    var treeNode = nodesUnderPoint.filter(node -> {
+      return Std.isOfType(node, TreeViewNode);
+    })[0];
+
+    if (treeNode != null) {
+      selectedNode = cast treeNode;
+    }
+  }
+
   @:bind(this, MouseEvent.RIGHT_MOUSE_DOWN)
   private function onContextMenu(e: MouseEvent) {
+    forceSelectNode(e.screenX, e.screenY);
     if (selectedNode != null) {
       if (selectedNode.hitTest(e.screenX, e.screenY)) {
         contextMenu.left = e.screenX;

--- a/src/views/MainView.hx
+++ b/src/views/MainView.hx
@@ -1,42 +1,15 @@
 package views;
 
 import haxe.ui.containers.windows.WindowManager;
-import components.MapEditor;
-import haxe.ui.core.Screen;
-import haxe.ui.events.MouseEvent;
-import components.menus.ContextMenu;
 import haxe.ui.containers.VBox;
+import components.MapEditor;
 
 @:build(haxe.ui.ComponentBuilder.build('assets/main/main-view.xml'))
 class MainView extends VBox {
-  public var contextMenu: ContextMenu;
 
   public function new() {
     super();
     WindowManager.instance.container = mainView;
-    contextMenu = new ContextMenu();
-
-    Screen.instance.registerEvent(MouseEvent.MOUSE_DOWN, function(e) {
-      if (e.buttonDown == 1) {
-        contextMenu.left = e.screenX;
-        contextMenu.top = e.screenY;
-        Screen.instance.addComponent(contextMenu);
-        contextMenu.hide();
-      }
-    });
-  }
-
-  public override function onReady() {
-    mapList.onRightClick = onMapListRightClick;
-  }
-
-  public function onMapListRightClick(e: MouseEvent) {
-    if (mapList.selectedNode != null) {
-      if (mapList.selectedNode.hitTest(e.screenX, e.screenY)) {
-        contextMenu.items = mapList.menu();
-        contextMenu.show();
-      }
-    }
   }
 
   public function update(dt) {


### PR DESCRIPTION
Also fixes small issue where the context menu for the map list would not appear until a tree node was selected.