### PR TITLE
Add enableTexture to Grid shader and component

### DIFF
--- a/assets/shaders/grid.frag
+++ b/assets/shaders/grid.frag
@@ -13,6 +13,7 @@ uniform float alpha;
 uniform float scale;
 uniform vec2 resolution;
 uniform sampler2D tex0;
+uniform float enableTexture;
 
 vec2 texSize;
 
@@ -35,5 +36,9 @@ void main() {
   float line = (min(grid.x, grid.y) / thickness) / scale;
   vec4 lineColor = color * (1.0 - min(line, 1.0));
 
-  outColor = (lineColor * alpha) + texColor;
+  if (enableTexture >= 1.0) {
+    outColor = (lineColor * alpha) + texColor;
+  } else {
+    outColor = lineColor * alpha;
+  }
 }

--- a/src/renderer/Grid.hx
+++ b/src/renderer/Grid.hx
@@ -31,7 +31,7 @@ class Grid extends Entity implements Component implements Observable {
 
   public function new() {
     super();
-    shader = app.assets.shader(Shaders.SHADERS__GRID);
+    shader = app.assets.shader(Shaders.SHADERS__GRID).clone();
     shader.setVec2('size', 16, 16);
     shader.setColor('color', Color.WHITE);
     shader.setFloat('alpha', alpha);

--- a/src/renderer/Grid.hx
+++ b/src/renderer/Grid.hx
@@ -37,6 +37,7 @@ class Grid extends Entity implements Component implements Observable {
     shader.setFloat('alpha', alpha);
     shader.setFloat('thickness', thickness);
     shader.setFloat('scale', scale);
+    shader.setFloat('enableTexture', 0.0);
     onVisibleCellsChange(this, onVisibleCellsChanged);
   }
 

--- a/src/renderer/Grid.hx
+++ b/src/renderer/Grid.hx
@@ -20,6 +20,7 @@ class Grid extends Entity implements Component implements Observable {
   public var cols(default, null): Int;
   public var rows(default, null): Int;
   public var cellSize(default, set): Rect = new Rect(0, 0, 16, 16);
+  public var enableTexture(default, set): Bool;
   public var color(default, set): Color;
   public var alpha(default, set): Float = 0.5;
   public var scale(default, set): Float = 1.0;
@@ -53,6 +54,13 @@ class Grid extends Entity implements Component implements Observable {
       case false:
         visual.shader = null;
     }
+  }
+
+  function set_enableTexture(enable: Bool) {
+    if (this.enableTexture == enable) return enable;
+    this.enableTexture = enable;
+    shader.setFloat('enableTexture', enable ? 1.0 : 0.0);
+    return enable;
   }
 
   function set_thickness(thickness: Float) {


### PR DESCRIPTION
This adds an enableTexture property so we can choose whether or not the Grid shader draws the texture it's attatched to or only draw the grid.

I also did a small fix where the shader was not being cloned which essentially caused any changes made to grid apply to all objects that used it.