### PR TITLE
Refactor MapEditor to handle AppState changes instead of renderer objects

### DIFF
--- a/src/components/MapEditor.hx
+++ b/src/components/MapEditor.hx
@@ -23,6 +23,8 @@ class MapEditor extends VBox {
     selectionRect = new Rect();
     contextMenu = new ContextMenu();
     contextMenu.items = menu();
+    store.state.onActiveMapChange(null, onActiveMapChanged);
+    store.state.onTileSizeChange(null, onTileSizeChanged);
     store.state.onSelectedTilesChange(null, onSelectedTilesChanged);
     viewport = new TilemapViewport(tileView);
     viewport.onOnTilemapClick(null, onTilemapClick);
@@ -93,6 +95,14 @@ class MapEditor extends VBox {
 
   public override function onResized() {
     viewport.resize(48 * 20, 48 * 16);
+  }
+
+  function onTileSizeChanged(newSize: Rect, oldSize: Rect) {
+    tilePicker.changeTileSize(newSize);
+  }
+
+  function onActiveMapChanged(newMap: MapInfo, oldMap: MapInfo) {
+    tilePicker.changeActiveMap(newMap);
   }
 
   function onSelectedTilesChanged(newTiles: Array<Tile>, oldTiles: Array<Tile>) {

--- a/src/components/TilePicker.hx
+++ b/src/components/TilePicker.hx
@@ -22,8 +22,6 @@ class TilePicker extends VBox {
 
   public function new() {
     super();
-    store.state.onActiveMapChange(null, onActiveMapChanged);
-    store.state.onTileSizeChange(null, onTileSizeChanged);
     onMouseOver = handleZoomable;
     onMouseOut = handleZoomable;
     tileView.scrollMode = ScrollMode.NORMAL;
@@ -82,17 +80,17 @@ class TilePicker extends VBox {
     }
   }
 
-  function onTileSizeChanged(newSize, oldSize) {
+  public function changeTileSize(newSize: Rect) {
     tileCursor.size(newSize.width, newSize.height);
     tileset.grid.cellSize = newSize;
   }
 
-  function onActiveMapChanged(newMap: MapInfo, oldMap: MapInfo) {
-    if (newMap.path == null) {
+  public function changeActiveMap(map: MapInfo) {
+    if (map.path == null) {
       clearTilesets();
       return;
     }
-    var tilemapData = projectAssets.tilemapData(newMap.path);
+    var tilemapData = projectAssets.tilemapData(map.path);
     var tilesets = tilemapData.tilesets;
 
     clearTilesets();

--- a/src/renderer/TilemapViewport.hx
+++ b/src/renderer/TilemapViewport.hx
@@ -20,9 +20,8 @@ class TilemapViewport extends ceramic.Scene {
   public var gridOverlay: GridQuad;
 
   var mapPath: String;
-  var selectionRect: Rect;
 
-  @event function onTilemapClick(info: TouchInfo, tiles: Array<Tile>, selectionRect: Rect);
+  @event function onTilemapClick(info: TouchInfo, tiles: Array<Tile>);
 
   public function new(?parentView) {
     super();
@@ -31,12 +30,9 @@ class TilemapViewport extends ceramic.Scene {
     }
     depth = 1;
     screen.onPointerMove(this, onPointerMove);
-    store.state.onActiveMapChange(null, onActiveMapChanged);
-    store.state.onTileSizeChange(null, onTileSizeChanged);
-    store.state.onSelectedTilesChange(null, onSelectedTilesChanged);
   }
 
-  function onActiveMapChanged(newMap: MapInfo, oldMap: MapInfo) {
+  public function changeActiveMap(newMap: MapInfo) {
     if (newMap.path == null) {
       loadEmptyMap(newMap);
       return;
@@ -44,39 +40,12 @@ class TilemapViewport extends ceramic.Scene {
     loadMap(newMap);
   }
 
-  function onTileSizeChanged(newSize: Rect, oldSize: Rect) {
+  public function changeTileSize(newSize: Rect) {
     tileSize = newSize;
     tileCursor.size(tileSize.width, tileSize.height);
     mapCols = Math.round(tilemap.width / tileSize.width);
     mapRows = Math.round(tilemap.height / tileSize.height);
     gridOverlay.grid.cellSize = newSize;
-  }
-
-  // We definitely want this as a utility or somewhere else, this is the 2nd time using this.
-  public function createRectFromTiles(selectedCells: Array<Tile>, cellSize: Rect): Rect {
-    if (selectedCells.length == 0) {
-      return new Rect(0, 0, 0, 0);
-    }
-
-    var minX = selectedCells[0].position.x;
-    var minY = selectedCells[0].position.y;
-    var maxX = selectedCells[0].position.x;
-    var maxY = selectedCells[0].position.y;
-
-    for (cell in selectedCells) {
-      minX = Math.min(minX, cell.position.x);
-      minY = Math.min(minY, cell.position.y);
-      maxX = Math.max(maxX, cell.position.x);
-      maxY = Math.max(maxY, cell.position.y);
-    }
-
-    return new Rect(minX, minY, (maxX - minX) + cellSize.width, (maxY - minY) + cellSize.height);
-  }
-
-  function onSelectedTilesChanged(newTiles: Array<Tile>, oldTiles: Array<Tile>) {
-    if (newTiles.length <= 0) return;
-    selectionRect = createRectFromTiles(newTiles, tileSize);
-    tileCursor.size(selectionRect.width, selectionRect.height);
   }
 
   public override function preload() {}
@@ -188,6 +157,6 @@ class TilemapViewport extends ceramic.Scene {
   }
 
   function onGridClick (info: TouchInfo, tiles: Array<Cell>) { 
-    emitOnTilemapClick(info, tiles, selectionRect);
+    emitOnTilemapClick(info, tiles);
   }
 }


### PR DESCRIPTION
This moves all AppState listeners in TilemapViewport and TilePicker into MapEditor where things should be handled and accesible more efficently.