### PR TITLE
Add mapchange event

### DIFF
--- a/src/MapEvent.hx
+++ b/src/MapEvent.hx
@@ -7,4 +7,7 @@ class MapEvent extends UIEvent {
 
   /* Dispatched when a layer's visibility has changed' */
   public static final LAYER_VISIBILITY: EventType<UIEvent> = EventType.name('layerVisiblChange');
+
+  /* Dispatched when a map has been selected' */
+  public static final MAP_SELECT: EventType<UIEvent> = EventType.name('mapSelect');
 }

--- a/src/components/MapEditor.hx
+++ b/src/components/MapEditor.hx
@@ -26,13 +26,13 @@ class MapEditor extends VBox {
     selectionRect = new Rect();
     contextMenu = new ContextMenu();
     contextMenu.items = menu();
-    store.state.onActiveMapChange(null, onActiveMapChanged);
     store.state.onTileSizeChange(null, onTileSizeChanged);
     store.state.onSelectedTilesChange(null, onSelectedTilesChanged);
     viewport = new TilemapViewport(tileView);
     viewport.onOnTilemapClick(null, onTilemapClick);
     layerPanel.registerEvent(MapEvent.LAYER_VISIBILITY, onLayerVisibilityChange);
     layerPanel.registerEvent(MapEvent.LAYER_RENAME, onLayerRename);
+    mapListPanel.registerEvent(MapEvent.MAP_SELECT, onActiveMapChanged);
   }
 
   public function menu(): Array<ContextMenuEntry> {
@@ -108,12 +108,13 @@ class MapEditor extends VBox {
     viewport.changeTileSize(newSize);
   }
 
-  function onActiveMapChanged(newMap: MapInfo, oldMap: MapInfo) {
-    tilemapData = projectAssets.tilemapData(newMap.path);
+  function onActiveMapChanged(event: UIEvent) {
+    var map: MapInfo = event.data;
+    tilemapData = projectAssets.tilemapData(map.path);
     layerPanel.layers = tilemapData.layers;
     layerPanel.list.selectedIndex = 0;
-    tilePicker.changeActiveMap(newMap);
-    viewport.changeActiveMap(newMap);
+    tilePicker.changeActiveMap(map);
+    viewport.changeActiveMap(map);
   }
 
   function onSelectedTilesChanged(newTiles: Array<Tile>, oldTiles: Array<Tile>) {

--- a/src/components/MapsPanel.hx
+++ b/src/components/MapsPanel.hx
@@ -1,5 +1,6 @@
 package components;
 
+import haxe.ui.events.UIEvent;
 import haxe.ui.containers.Panel;
 import haxe.ui.core.Screen;
 import haxe.ui.events.MouseEvent;
@@ -138,7 +139,8 @@ class MapsPanel extends Panel {
         id: selectedNode.data.id,
         path: selectedNode.data.path
       }
-      store.commit.updateActiveMap(mapInfo);
+      final mapEvent = new UIEvent(MapEvent.MAP_SELECT, false, mapInfo);
+      dispatch(mapEvent);
     }, 25);
   }
 


### PR DESCRIPTION
Adds an event for when a map is selected from the MapListPanel and refactors it so MapEditor handles it instead of AppStore.