### PR TITLE
Refactor property names in Tilemap

### DIFF
--- a/src/components/tilemap/TilePicker.hx
+++ b/src/components/tilemap/TilePicker.hx
@@ -167,7 +167,7 @@ class TilePicker extends VBox {
     if (isMiddleMouseClick) {
       return;
     }
-    final event = new MapEvent(MapEvent.TILE_SELECTION, false, cells);
+    final event = new MapEvent(MapEvent.TILESET_TILE_SELECTION, false, cells);
     dispatch(event);
   }
 }

--- a/src/components/tilemap/Tilemap.hx
+++ b/src/components/tilemap/Tilemap.hx
@@ -196,23 +196,23 @@ class Tilemap extends ScrollView {
     if (layer != null) layer.contentDirty = true;
   }
 
-  function eraseTile(tilesToEdit: Array<Tile>) {
+  function eraseTile(cellsToEdit: Array<Cell>) {
     var tiles = getActiveLayerTiles();
     if (tiles == null) return;
-    for (index => tile in tilesToEdit) {
-      tiles[tile.frame] = 0;
+    for (index => cell in cellsToEdit) {
+      tiles[cell.frame] = 0;
     }
     updateLayerTiles(tiles);
   }
 
-  function drawTile(tilesToEdit: Array<Tile>) {
+  function drawTile(cellsToEdit: Array<Cell>) {
     var tiles = getActiveLayerTiles();
     if (tiles == null) return;
 
-    for (index => tile in tilesToEdit) {
+    for (index => cell in cellsToEdit) {
       var tilemapTile = tilesetTiles[index];
-      if (withinTilemapBounds(tile.position.x, tile.position.y)) {
-        tiles[tile.frame] = tilemapTile;
+      if (withinTilemapBounds(cell.position.x, cell.position.y)) {
+        tiles[cell.frame] = tilemapTile;
       }
     }
     updateLayerTiles(tiles);
@@ -224,29 +224,29 @@ class Tilemap extends ScrollView {
 
   function handleTilemapAction(x: Float, y: Float) {
     if (buttonId < 0) return;
-    var tilesToEdit = overlay.grid.getCellsFromRect(
+    var cellsToEdit = overlay.grid.getCellsFromRect(
       new Rect(x, y, selectionRect.width, selectionRect.height)
     );
 
     if (buttonId == 0) {
-      drawTile(tilesToEdit);
+      drawTile(cellsToEdit);
     } else if (buttonId == 2) {
-      eraseTile(tilesToEdit);
+      eraseTile(cellsToEdit);
     }
   }
 
-  function handleGridPointerMove(tiles: Array<Cell>, _) {
+  function handleGridPointerMove(cells: Array<Cell>, _) {
     if (activeLayer != null && selectionRect != null) {
-      handleTilemapAction(tiles[0].position.x, tiles[0].position.y);
+      handleTilemapAction(cells[0].position.x, cells[0].position.y);
     }
   }
 
-  function handleGridClick (info: TouchInfo, tiles: Array<Cell>) { 
+  function handleGridClick (info: TouchInfo, cells: Array<Cell>) { 
     if (activeLayer == null) return;
-    var selectedTile = tiles[0];
-    var tilePos = selectedTile.position;
+    var selectedCell = cells[0];
+    var cellPos = selectedCell.position;
     buttonId = info.buttonId;
-    handleTilemapAction(tilePos.x, tilePos.y);
+    handleTilemapAction(cellPos.x, cellPos.y);
   }
 
   function handlePointerUp(info: TouchInfo) {

--- a/src/components/tilemap/Tilemap.hx
+++ b/src/components/tilemap/Tilemap.hx
@@ -26,7 +26,7 @@ class Tilemap extends ScrollView {
   public var activeLayer(default, set): TilemapLayerData;
   public var selectedTiles(default, set): Array<Tile>; 
   
-  var tilemapTiles: Array<TilemapTile>;
+  var tilesetTiles: Array<TilemapTile>;
   var selectionRect: Rect;
   var viewport: Visual;
   var buttonId: Int = -1;
@@ -50,9 +50,9 @@ class Tilemap extends ScrollView {
 
   function set_selectedTiles(tiles: Array<Tile>) {
     if (selectedTiles == tiles) return tiles;
-    tilemapTiles = [];
+    tilesetTiles = [];
     for (tile in tiles) {
-      tilemapTiles.push(new TilemapTile(tile.frame));
+      tilesetTiles.push(new TilemapTile(tile.frame));
     }
     selectedTiles = tiles;
     selectionRect = overlay.grid.createRectFromCells(cast selectedTiles, tileSize);
@@ -210,7 +210,7 @@ class Tilemap extends ScrollView {
     if (tiles == null) return;
 
     for (index => tile in tilesToEdit) {
-      var tilemapTile = tilemapTiles[index];
+      var tilemapTile = tilesetTiles[index];
       if (withinTilemapBounds(tile.position.x, tile.position.y)) {
         tiles[tile.frame] = tilemapTile;
       }

--- a/src/components/tilemap/Tilemap.hx
+++ b/src/components/tilemap/Tilemap.hx
@@ -55,7 +55,7 @@ class Tilemap extends ScrollView {
       selectedTilesetTiles.push(new TilemapTile(cell.frame));
     }
     selectedTilesetCells = cells;
-    selectionRect = overlay.grid.createRectFromCells(cast selectedTilesetCells, tileSize);
+    selectionRect = overlay.grid.createRectFromCells(selectedTilesetCells, tileSize);
     tileCursor.size(selectionRect.width, selectionRect.height);
     return cells;
   }

--- a/src/components/tilemap/Tilemap.hx
+++ b/src/components/tilemap/Tilemap.hx
@@ -27,7 +27,7 @@ class Tilemap extends ScrollView {
   public var selectedTilesetCells(default, set): Array<Cell>; 
   
   var selectedTilesetTiles: Array<TilemapTile>;
-  var selectionRect: Rect;
+  var tilesetRect: Rect;
   var viewport: Visual;
   var buttonId: Int = -1;
   var zoomable = new Zoomable();
@@ -55,8 +55,8 @@ class Tilemap extends ScrollView {
       selectedTilesetTiles.push(new TilemapTile(cell.frame));
     }
     selectedTilesetCells = cells;
-    selectionRect = overlay.grid.createRectFromCells(selectedTilesetCells, tileSize);
-    tileCursor.size(selectionRect.width, selectionRect.height);
+    tilesetRect = overlay.grid.createRectFromCells(selectedTilesetCells, tileSize);
+    tileCursor.size(tilesetRect.width, tilesetRect.height);
     return cells;
   }
 
@@ -225,7 +225,7 @@ class Tilemap extends ScrollView {
   function handleTilemapAction(x: Float, y: Float) {
     if (buttonId < 0) return;
     var cellsToEdit = overlay.grid.getCellsFromRect(
-      new Rect(x, y, selectionRect.width, selectionRect.height)
+      new Rect(x, y, tilesetRect.width, tilesetRect.height)
     );
 
     if (buttonId == 0) {
@@ -236,7 +236,7 @@ class Tilemap extends ScrollView {
   }
 
   function handleGridPointerMove(cells: Array<Cell>, _) {
-    if (activeLayer != null && selectionRect != null) {
+    if (activeLayer != null && tilesetRect != null) {
       handleTilemapAction(cells[0].position.x, cells[0].position.y);
     }
   }

--- a/src/components/tilemap/Tilemap.hx
+++ b/src/components/tilemap/Tilemap.hx
@@ -24,9 +24,9 @@ class Tilemap extends ScrollView {
   public var tileCursor: Border;
   public var overlay: GridQuad;
   public var activeLayer(default, set): TilemapLayerData;
-  public var selectedCells(default, set): Array<Cell>; 
+  public var selectedTilesetCells(default, set): Array<Cell>; 
   
-  var tilesetTiles: Array<TilemapTile>;
+  var selectedTilesetTiles: Array<TilemapTile>;
   var selectionRect: Rect;
   var viewport: Visual;
   var buttonId: Int = -1;
@@ -48,14 +48,14 @@ class Tilemap extends ScrollView {
     return layer;
   }
 
-  function set_selectedCells(cells: Array<Cell>) {
-    if (selectedCells == cells) return cells;
-    tilesetTiles = [];
+  function set_selectedTilesetCells(cells: Array<Cell>) {
+    if (selectedTilesetCells == cells) return cells;
+    selectedTilesetTiles = [];
     for (cell in cells) {
-      tilesetTiles.push(new TilemapTile(cell.frame));
+      selectedTilesetTiles.push(new TilemapTile(cell.frame));
     }
-    selectedCells = cells;
-    selectionRect = overlay.grid.createRectFromCells(cast selectedCells, tileSize);
+    selectedTilesetCells = cells;
+    selectionRect = overlay.grid.createRectFromCells(cast selectedTilesetCells, tileSize);
     tileCursor.size(selectionRect.width, selectionRect.height);
     return cells;
   }
@@ -210,7 +210,7 @@ class Tilemap extends ScrollView {
     if (tiles == null) return;
 
     for (index => cell in cellsToEdit) {
-      var tilemapTile = tilesetTiles[index];
+      var tilemapTile = selectedTilesetTiles[index];
       if (withinTilemapBounds(cell.position.x, cell.position.y)) {
         tiles[cell.frame] = tilemapTile;
       }

--- a/src/components/tilemap/Tilemap.hx
+++ b/src/components/tilemap/Tilemap.hx
@@ -24,7 +24,7 @@ class Tilemap extends ScrollView {
   public var tileCursor: Border;
   public var overlay: GridQuad;
   public var activeLayer(default, set): TilemapLayerData;
-  public var selectedTiles(default, set): Array<Tile>; 
+  public var selectedCells(default, set): Array<Cell>; 
   
   var tilesetTiles: Array<TilemapTile>;
   var selectionRect: Rect;
@@ -48,16 +48,16 @@ class Tilemap extends ScrollView {
     return layer;
   }
 
-  function set_selectedTiles(tiles: Array<Tile>) {
-    if (selectedTiles == tiles) return tiles;
+  function set_selectedCells(cells: Array<Cell>) {
+    if (selectedCells == cells) return cells;
     tilesetTiles = [];
-    for (tile in tiles) {
-      tilesetTiles.push(new TilemapTile(tile.frame));
+    for (cell in cells) {
+      tilesetTiles.push(new TilemapTile(cell.frame));
     }
-    selectedTiles = tiles;
-    selectionRect = overlay.grid.createRectFromCells(cast selectedTiles, tileSize);
+    selectedCells = cells;
+    selectionRect = overlay.grid.createRectFromCells(cast selectedCells, tileSize);
     tileCursor.size(selectionRect.width, selectionRect.height);
-    return tiles;
+    return cells;
   }
 
   public override function onReady() {

--- a/src/constants/MapEvent.hx
+++ b/src/constants/MapEvent.hx
@@ -16,8 +16,8 @@ class MapEvent extends UIEvent {
   /* Dispatched when a map has been selected' */
   public static final MAP_SELECT: EventType<UIEvent> = EventType.name('mapSelect');
 
-  /* Dispatched when a map has been selected' */
-  public static final TILE_SELECTION: EventType<UIEvent> = EventType.name('tileSelection');
+  /* Dispatched when a tile(s) has been selected from the tileset' */
+  public static final TILESET_TILE_SELECTION: EventType<UIEvent> = EventType.name('tilesetTileSelection');
 
   /* Dispatched when the tilemap is clicked' */
   public static final MAP_CLICK: EventType<UIEvent> = EventType.name('mapClick');

--- a/src/views/MapEditor.hx
+++ b/src/views/MapEditor.hx
@@ -114,7 +114,7 @@ class MapEditor extends VBox {
   function onTileSelection(event: UIEvent) {
     var cells: Array<Cell> = cast event.data;
     if (tilemapView == null || cells.length <= 0) return;
-    tilemapView.selectedCells = cells;
+    tilemapView.selectedTilesetCells = cells;
   }
 
   function onActiveMapChanged(event: UIEvent) {

--- a/src/views/MapEditor.hx
+++ b/src/views/MapEditor.hx
@@ -1,5 +1,6 @@
 package views;
 
+import renderer.Grid.Cell;
 import haxe.ui.events.UIEvent;
 import ceramic.Rect;
 import components.menus.ContextMenu;
@@ -111,9 +112,9 @@ class MapEditor extends VBox {
   }
 
   function onTileSelection(event: UIEvent) {
-    var tiles: Array<Tile> = cast event.data;
-    if (tilemapView == null || tiles.length <= 0) return;
-    tilemapView.selectedTiles = tiles;
+    var cells: Array<Cell> = cast event.data;
+    if (tilemapView == null || cells.length <= 0) return;
+    tilemapView.selectedCells = cells;
   }
 
   function onActiveMapChanged(event: UIEvent) {

--- a/src/views/MapEditor.hx
+++ b/src/views/MapEditor.hx
@@ -25,7 +25,7 @@ class MapEditor extends VBox {
     layerPanel.registerEvent(MapEvent.LAYER_VISIBILITY, onLayerVisibilityChange);
     layerPanel.registerEvent(MapEvent.LAYER_RENAME, onLayerRename);
     mapListPanel.registerEvent(MapEvent.MAP_SELECT, onActiveMapChanged);
-    tilePicker.registerEvent(MapEvent.TILE_SELECTION, onTileSelection);
+    tilePicker.registerEvent(MapEvent.TILESET_TILE_SELECTION, onTileSelection);
   }
 
   public function menu(): Array<ContextMenuEntry> {


### PR DESCRIPTION
This refactor property names in Tilemap to help with readability and add calirification between tileset tiles, cells and tilemap tiles and cells.